### PR TITLE
Enable speech only when planchette is pressed

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,8 @@
     #planchette {
       position: absolute;
       width: 200px;
-      pointer-events: none;
+      pointer-events: auto;
+      cursor: pointer;
       transition: top 0.8s ease, left 0.8s ease;
       z-index: 10;
     }
@@ -112,6 +113,23 @@
   rec.continuous = true;
   rec.interimResults = true;
 
+  const planchetteEl = document.getElementById('planchette');
+  let listening = false;
+
+  function startListening() {
+    listening = true;
+    try { rec.start(); } catch (_) {}
+  }
+
+  function stopListening() {
+    listening = false;
+    try { rec.stop(); } catch (_) {}
+  }
+
+  planchetteEl.addEventListener('pointerdown', startListening);
+  planchetteEl.addEventListener('pointerup', stopListening);
+  planchetteEl.addEventListener('pointerleave', stopListening);
+
   let buffer = '';
   let lastFinalAt = 0;
   const FLUSH_AFTER_MS = 1200; // send after ~1.2s of silence
@@ -130,8 +148,9 @@
   };
 
   rec.onend = () => {
-    // keep it running
-    try { rec.start(); } catch (_) {}
+    if (listening) {
+      try { rec.start(); } catch (_) {}
+    }
   };
 
   function flush() {
@@ -153,7 +172,6 @@
     if (buffer && Date.now() - lastFinalAt > FLUSH_AFTER_MS) flush();
   }, 500);
 
-  try { rec.start(); } catch (e) { console.error(e); }
 })();
 </script>
 


### PR DESCRIPTION
## Summary
- make the planchette clickable so it can capture pointer events
- start speech recognition on pointer down and stop on pointer up/leave

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68853b7b78d883238e467a401734d8d2