### PR TITLE
Add backend handling for spirit switch tokens

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,10 +196,6 @@
         const resp = await fetch('ouija.php?q=' + encodeURIComponent(question));
         const raw = (await resp.text()).trim();
         let answer = raw.replace(/[^A-Za-z0-9 ]+/g, ' ').replace(/\s+/g, ' ').trim();
-        if (raw.includes('<<RESET>>')) {
-          await fetch('ouija.php?action=reset');
-          answer = 'HELLO';
-        }
         await ask(answer);
         addMessage('response', answer);
       } catch (err) {

--- a/ouija.php
+++ b/ouija.php
@@ -309,11 +309,24 @@ if ($action === 'ask') {
 
     $response = clean_output($response);
 
+    // Check for special tokens indicating a new spirit should be summoned
+    $resetToken = false;
+    if (strpos($response, '<<NEW_SPIRIT>>') !== false || strpos($response, '<<RESET>>') !== false) {
+        $resetToken = true;
+        $response = str_replace(['<<NEW_SPIRIT>>', '<<RESET>>'], '', $response);
+        $response = clean_output($response);
+    }
+
     // Append assistant reply to memory
     $spirit['conversation'][] = ['role' => 'assistant', 'content' => $response];
 
-    // Save spirit back
+    // Save spirit back before potentially resetting
     save_spirit($SPIRITS_DIR, $spirit);
+
+    if ($resetToken) {
+        // Create and load a new spirit for subsequent requests
+        $spirit = summon_new_spirit($API_KEY, $MODEL, $SYSTEM_PROMPT, $TEMPERATURE, $MAX_TOKENS, $SPIRITS_DIR, $CURRENT_FILE);
+    }
 
     // Output only the spirit's answer
     echo $response;


### PR DESCRIPTION
## Summary
- detect `<<NEW_SPIRIT>>` (or legacy `<<RESET>>`) in `ouija.php`
- create a new spirit when such tokens appear and strip them from the output
- move reset logic out of the frontend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886c9728dec8323a10302fb98cff408