### PR TITLE
feat: run LLM in browser with workers

### DIFF
--- a/ai-worker.js
+++ b/ai-worker.js
@@ -1,0 +1,28 @@
+importScripts('https://cdn.jsdelivr.net/npm/@mlc-ai/web-llm/dist/index.min.js');
+
+let engine;
+
+// Respond to messages from the main thread.
+self.onmessage = async (event) => {
+    const data = event.data;
+    if (data.type === 'init') {
+        // Load the model inside the worker so UI remains responsive.
+        engine = await webllm.createMLCEngine('Llama-3.1-8B-Instruct-q4f32_1-MLC');
+        self.postMessage({ type: 'ready' });
+    } else if (data.type === 'question') {
+        if (!engine) {
+            self.postMessage({ type: 'error', error: 'Engine not initialized' });
+            return;
+        }
+        try {
+            // Generate a response from the local model.
+            const result = await engine.chat.completions.create({
+                messages: [{ role: 'user', content: data.question }]
+            });
+            const text = result.choices[0].message.content;
+            self.postMessage({ type: 'answer', answer: text });
+        } catch (err) {
+            self.postMessage({ type: 'error', error: err.message });
+        }
+    }
+};

--- a/index.html
+++ b/index.html
@@ -166,6 +166,20 @@
         startAnimation();
       }
     });
+    
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('service-worker.js');
+    }
+    
+    const aiWorker = new Worker('ai-worker.js');
+    const aiReady = new Promise((resolve) => {
+      aiWorker.addEventListener('message', (e) => {
+        if (e.data.type === 'ready') {
+          resolve();
+        }
+      });
+    });
+    aiWorker.postMessage({ type: 'init' });
 
     const letterPositions = {
       "0": [666, 437], "1": [237, 437], "2": [280, 439], "3": [329, 441],
@@ -227,18 +241,25 @@
     async function askOuija(question) {
       addMessage('question', question);
       try {
-        const resp = await fetch('ouija.php?q=' + encodeURIComponent(question));
-        const raw = (await resp.text()).trim();
-        let answer = raw.replace(/[^A-Za-z0-9 ]+/g, ' ').replace(/\s+/g, ' ').trim();
-
-        if (raw.includes('<<NEW_SPIRIT>>')) {
-          await fetch('ouija.php?action=reset');
-          answer = 'HELLO';
-        }
-        await ask(answer);
-        addMessage('response', answer);
+        await aiReady;
+        const answer = await new Promise((resolve, reject) => {
+          function handler(e) {
+            if (e.data.type === 'answer') {
+              aiWorker.removeEventListener('message', handler);
+              resolve(e.data.answer);
+            } else if (e.data.type === 'error') {
+              aiWorker.removeEventListener('message', handler);
+              reject(new Error(e.data.error));
+            }
+          }
+          aiWorker.addEventListener('message', handler);
+          aiWorker.postMessage({ type: 'question', question });
+        });
+        const cleaned = answer.replace(/[^A-Za-z0-9 ]+/g, ' ').replace(/\s+/g, ' ').trim();
+        await ask(cleaned);
+        addMessage('response', cleaned);
       } catch (err) {
-        console.error('Ouija request failed:', err);
+        console.error('Ouija worker failed:', err);
       }
     }
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,29 @@
+const CACHE_NAME = 'llm-cache-v1';
+
+// Prepare cache on install so model files can be stored later.
+self.addEventListener('install', (event) => {
+    self.skipWaiting();
+    event.waitUntil(caches.open(CACHE_NAME));
+});
+
+// Take control of clients as soon as possible.
+self.addEventListener('activate', (event) => {
+    event.waitUntil(self.clients.claim());
+});
+
+// Cache model artifacts as they are fetched so they are available offline.
+self.addEventListener('fetch', (event) => {
+    const url = event.request.url;
+    if (url.includes('Llama-3.1-8B-Instruct-q4f32_1-MLC')) {
+        event.respondWith(
+            caches.open(CACHE_NAME).then((cache) => {
+                return cache.match(event.request).then((resp) => {
+                    return resp || fetch(event.request).then((networkResp) => {
+                        cache.put(event.request, networkResp.clone());
+                        return networkResp;
+                    });
+                });
+            })
+        );
+    }
+});


### PR DESCRIPTION
## Summary
- cache model files with a service worker for offline usage
- run Llama-3.1-8B-Instruct-q4f32_1-MLC in a web worker
- hook index.html up to the local worker for all Ouija questions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b339162a88832398dbaa8ed5f3a7d0